### PR TITLE
ci: harden pipeline with format verification and pack validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,14 @@ jobs:
       - name: Restore
         run: dotnet restore
 
+      - name: Verify formatting
+        run: dotnet format --verify-no-changes --no-restore
+
       - name: Build
         run: dotnet build --no-restore --configuration Release --warnaserror
 
       - name: Test
         run: dotnet test --no-build --configuration Release
+
+      - name: Pack
+        run: dotnet pack --no-build --configuration Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Pack
         run: |
-          PACK_ARGS="--configuration Release --output ./artifacts"
+          PACK_ARGS="--no-build --configuration Release --output ./artifacts"
           dotnet pack $PACK_ARGS
 
       - name: Upload packages as workflow artifact


### PR DESCRIPTION
## Summary

Hardens the CI pipeline before 1.0 by adding two new quality gates to `ci.yml` and tightening `publish.yml`.

## Changes

### `ci.yml`
- **Format verification** — added `dotnet format --verify-no-changes --no-restore` after restore and before build, so formatting drift fails CI fast
- **Pack validation** — added `dotnet pack --no-build --configuration Release` after test to confirm all NuGet packages can be packed successfully; sample and test projects are skipped automatically via `IsPackable=false`

### `publish.yml`
- Added `--no-build` to the `Pack` step — build has already run at that point, so this avoids a redundant compilation

## CI step order (after this PR)

`restore` → `verify formatting` → `build` → `test` → `pack`

## Notes
- No structural redesign — changes are minimal and focused
- Publish gating is unchanged: `workflow_dispatch` → GitHub Packages; `release` event → GitHub Release + NuGet.org; `--skip-duplicate` remains on all push steps
